### PR TITLE
Skip updating current user's contact

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# FOGIS Credentials
+FOGIS_USERNAME=your_fogis_username
+FOGIS_PASSWORD=your_fogis_password
+
+# Optional: Google API credentials path (if not in the same directory)
+# GOOGLE_CREDENTIALS_PATH=path/to/credentials.json
+
+# Optional: Your referee number to avoid updating your own contact
+# USER_REFEREE_NUMBER=your_referee_number

--- a/fogis_contacts.py
+++ b/fogis_contacts.py
@@ -139,7 +139,9 @@ def process_referees(match):
     # Get the user's referee number from environment variable
     user_referee_number = os.environ.get("USER_REFEREE_NUMBER")
     if user_referee_number:
-        logging.info(f"User referee number set to {user_referee_number}, will skip updating this contact")
+        logging.info(
+            f"User referee number set to {user_referee_number}, will skip updating this contact"
+        )
 
     try:
         service = build("people", "v1", credentials=creds)
@@ -151,7 +153,9 @@ def process_referees(match):
 
             # Skip updating the current user's contact
             if user_referee_number and referee_number == user_referee_number:
-                logging.info(f"Skipping contact update for current user: {name} (Referee #{referee_number})")
+                logging.info(
+                    f"Skipping contact update for current user: {name} (Referee #{referee_number})"
+                )
                 continue
 
             try:

--- a/fogis_contacts.py
+++ b/fogis_contacts.py
@@ -136,12 +136,24 @@ def process_referees(match):
         logging.error("Failed to obtain Google People API credentials for referee processing.")
         return False
 
+    # Get the user's referee number from environment variable
+    user_referee_number = os.environ.get("USER_REFEREE_NUMBER")
+    if user_referee_number:
+        logging.info(f"User referee number set to {user_referee_number}, will skip updating this contact")
+
     try:
         service = build("people", "v1", credentials=creds)
 
         for referee in match["domaruppdraglista"]:
             name = referee["personnamn"]
             phone = referee["mobiltelefon"]
+            referee_number = referee.get("domarnr")
+
+            # Skip updating the current user's contact
+            if user_referee_number and referee_number == user_referee_number:
+                logging.info(f"Skipping contact update for current user: {name} (Referee #{referee_number})")
+                continue
+
             try:
                 existing_contact = find_contact_by_name_and_phone(service, name, phone, referee)
 


### PR DESCRIPTION
# Skip Updating Current User's Contact

## Problem
Currently, the script updates contact information for all referees on every sync, including the current user. This is inefficient and unnecessary since the user's own contact information doesn't need to be updated.

## Solution
- Added `USER_REFEREE_NUMBER` environment variable to identify the current user
- Modified `process_referees` function to skip updating contacts that match the user's referee number
- Updated `.env.example` with the new environment variable
- Updated README.md with documentation for the new feature

## Implementation Details
- The script now checks if the referee's `domarnr` matches the `USER_REFEREE_NUMBER` environment variable
- If there's a match, it skips the contact update/creation process for that referee
- Added appropriate logging to inform the user when their contact is being skipped

## Testing
Tested by:
- Setting `USER_REFEREE_NUMBER` to a referee number in the match data
- Verifying that the script skips updating that referee's contact
- Confirming that other referees' contacts are still updated as expected

Fixes #41
