### PR TITLE
Add organization PR tracker workflow

### DIFF
--- a/.github/workflows/pr-tracker.yml
+++ b/.github/workflows/pr-tracker.yml
@@ -1,0 +1,125 @@
+name: PR Tracker
+
+on:
+  pull_request:
+    types: [opened, reopened, converted_to_draft, ready_for_review, closed]
+
+jobs:
+  track_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add PR to organization project
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const projectId = 'PVT_kwDODF_kVc4A4M8N';  // Organization PR Tracker project ID
+            
+            // Add the PR to the project
+            const addToProject = async () => {
+              try {
+                const result = await github.graphql(`
+                  mutation {
+                    addProjectV2ItemById(input: {
+                      projectId: "${projectId}",
+                      contentId: "${context.payload.pull_request.node_id}"
+                    }) {
+                      item {
+                        id
+                      }
+                    }
+                  }
+                `);
+                
+                console.log(`Added PR #${context.payload.pull_request.number} to organization PR tracker project`);
+                return result.addProjectV2ItemById.item.id;
+              } catch (error) {
+                // If the PR is already in the project, this will fail but we can ignore it
+                console.log(`Note: PR may already be in the project: ${error.message}`);
+                return null;
+              }
+            };
+            
+            // Update PR status based on the event
+            const updatePRStatus = async (itemId) => {
+              if (!itemId) return;
+              
+              // Get the status field ID
+              const projectData = await github.graphql(`
+                query {
+                  organization(login: "${context.repo.owner}") {
+                    projectV2(number: 3) {
+                      fields(first: 20) {
+                        nodes {
+                          ... on ProjectV2FieldCommon {
+                            id
+                            name
+                          }
+                          ... on ProjectV2SingleSelectField {
+                            id
+                            name
+                            options {
+                              id
+                              name
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              `);
+              
+              const fields = projectData.organization.projectV2.fields.nodes;
+              const statusField = fields.find(field => field.name === "PR Status");
+              
+              if (!statusField) {
+                console.log("PR Status field not found");
+                return;
+              }
+              
+              let statusOptionId;
+              
+              // Determine the status based on the PR event
+              if (context.payload.action === "closed") {
+                if (context.payload.pull_request.merged) {
+                  statusOptionId = statusField.options.find(option => option.name === "Merged").id;
+                } else {
+                  statusOptionId = statusField.options.find(option => option.name === "Closed").id;
+                }
+              } else if (context.payload.pull_request.draft) {
+                statusOptionId = statusField.options.find(option => option.name === "Draft").id;
+              } else if (context.payload.action === "ready_for_review") {
+                statusOptionId = statusField.options.find(option => option.name === "Needs Review").id;
+              } else {
+                statusOptionId = statusField.options.find(option => option.name === "Open").id;
+              }
+              
+              // Update the status
+              await github.graphql(`
+                mutation {
+                  updateProjectV2ItemFieldValue(
+                    input: {
+                      projectId: "${projectId}",
+                      itemId: "${itemId}",
+                      fieldId: "${statusField.id}",
+                      value: { 
+                        singleSelectOptionId: "${statusOptionId}"
+                      }
+                    }
+                  ) {
+                    projectV2Item {
+                      id
+                    }
+                  }
+                }
+              `);
+              
+              console.log(`Updated PR status for PR #${context.payload.pull_request.number}`);
+            };
+            
+            // Main execution
+            const itemId = await addToProject();
+            if (itemId) {
+              await updatePRStatus(itemId);
+            }


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that automatically adds pull requests to the organization-wide PR tracker project board.

The PR tracker project board is available at: https://github.com/orgs/PitchConnect/projects/3

This workflow helps maintain visibility of all pull requests across the organization.