### PR TITLE
Adhere to new OAuth standards

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ python-dotenv==1.0.0
 requests==2.31.0
 werkzeug==3.0.1
 # Add fogis_api_client as a dependency with specific version
-fogis-api-client-timmyBird==0.5.1
+fogis-api-client-timmyBird==0.6.2


### PR DESCRIPTION
The Fogis server has been updated to use a OAuth 2.0 flow upon logging in. Similarly the API Client has now been updated to handle this. This update uses the new API Client