### PR TITLE
Fix: Use correct token path for Google People API authentication

### DIFF
--- a/fogis_contacts.py
+++ b/fogis_contacts.py
@@ -127,8 +127,10 @@ def authorize_google_people():
         google.oauth2.credentials.Credentials: Valid credentials or None if authentication fails
     """
     try:
-        # Use configurable token path (same as calendar sync)
-        token_path = os.environ.get("TOKEN_PATH", "token.json")
+        # Use same token path as calendar sync (token has both Calendar and People API scopes)
+        token_path = os.environ.get(
+            "GOOGLE_CALENDAR_TOKEN_FILE", "/app/credentials/tokens/calendar/token.json"
+        )
         logging.info("🔐 Google People API authentication in progress...")
         logging.info(f"📁 Using token path: {token_path}")
 


### PR DESCRIPTION
## Summary

Fixes Google People API authentication failure by correcting the token path configuration in `fogis_contacts.py`. This is a **path configuration bug**, not a missing credentials issue.

## Root Cause

**Problem:** `fogis_contacts.py` was using an incorrect default token path:
```python
token_path = os.environ.get("TOKEN_PATH", "token.json")  # ❌ Wrong relative path
```

**Issues:**
- Environment variable `TOKEN_PATH` was not set
- Default path `"token.json"` (relative) doesn't exist
- Caused authentication failure: `❌ Failed to obtain valid Google People API credentials`

**Observed in logs (2025-10-01 08:56:05):**
```
🔐 Google People API authentication in progress...
📁 Using token path: token.json
⚠️ OAuth authentication required - no valid credentials available
❌ Failed to obtain valid Google People API credentials
```

## Evidence: Credentials Already Exist

**Investigation revealed:**
- ✅ Existing token at `/app/credentials/tokens/calendar/token.json` **already has** People API scopes
- ✅ Token includes `https://www.googleapis.com/auth/contacts` scope
- ✅ Calendar service uses correct absolute path and works fine
- ✅ Same token can be used for both Calendar and People APIs

**Token scopes:**
```json
{
  "scopes": [
    "https://www.googleapis.com/auth/calendar",
    "https://www.googleapis.com/auth/contacts",  // ← HAS IT!
    "https://www.googleapis.com/auth/drive"
  ]
}
```

## Fix Applied

**Changed from:**
```python
token_path = os.environ.get("TOKEN_PATH", "token.json")
```

**Changed to:**
```python
token_path = os.environ.get(
    "GOOGLE_CALENDAR_TOKEN_FILE",  # Same env var as calendar service
    "/app/credentials/tokens/calendar/token.json"  # Correct absolute path
)
```

**Benefits:**
- ✅ Uses same environment variable as calendar service (`GOOGLE_CALENDAR_TOKEN_FILE`)
- ✅ Uses correct absolute path as default
- ✅ Both services now share the same token (which has both API scopes)
- ✅ No changes needed to deployment configuration (env var already set in docker-compose.yml)

## Files Changed

- `fogis_contacts.py` (lines 130-134)

## Impact

### Before Fix
- ❌ Google People API authentication fails
- ❌ Referee contacts NOT created in Google Contacts
- ❌ Referee phone numbers not available
- ✅ Calendar events still created (uses different code path)

### After Fix
- ✅ Google People API authentication succeeds
- ✅ Referee contacts created in Google Contacts
- ✅ Referee phone numbers available
- ✅ Calendar events continue to work

## Testing

### Verification Steps

1. **Deploy updated image:**
   ```bash
   docker-compose pull fogis-calendar-phonebook-sync
   docker-compose up -d fogis-calendar-phonebook-sync
   ```

2. **Trigger a match sync** (e.g., match 6143017)

3. **Check logs for successful authentication:**
   ```bash
   docker logs fogis-calendar-phonebook-sync | grep "People API"
   ```
   
   **Expected:**
   ```
   ✅ Successfully loaded Google People credentials from /app/data/google-calendar/token.json
   ✅ Google People API credentials obtained successfully
   ✅ Successfully processed 4 referee contacts
   ```

4. **Verify contacts in Google Contacts:**
   - Open Google Contacts
   - Search for referee names (e.g., "Toni Galic")
   - Verify contact exists with phone number

5. **Verify no regression in calendar events:**
   - Check that calendar events are still created
   - Verify referee information appears in event description

## Deployment Notes

### No Changes Needed to Deployment Repo

The `fogis-deployment` repository's `docker-compose.yml` **already sets** the correct environment variable:

```yaml
# Line 113 in docker-compose.yml
- GOOGLE_CALENDAR_TOKEN_FILE=/app/data/google-calendar/token.json
```

No changes needed to deployment configuration! ✅

### Deployment Process

1. **Merge this PR** → Triggers CI/CD
2. **CI/CD builds new image** → Pushes to GitHub Container Registry
3. **Update deployment repo** with new image SHA:
   ```yaml
   image: ghcr.io/pitchconnect/fogis-calendar-phonebook-sync:sha-<NEW_SHA>
   ```
4. **Deploy:**
   ```bash
   docker-compose pull fogis-calendar-phonebook-sync
   docker-compose up -d fogis-calendar-phonebook-sync
   ```

## Related Issues

- Fixes referee contact creation failure
- Related to investigation: `GOOGLE_PEOPLE_API_INVESTIGATION_FINDINGS.md`
- Part of broader calendar sync improvements

## Checklist

- [x] Code follows project style guidelines (black, flake8, isort)
- [x] All pre-commit hooks pass
- [x] All tests pass
- [x] Commit message follows conventional commits format
- [x] Changes are minimal and focused on the specific issue
- [x] No changes needed to deployment configuration
- [ ] Tested in staging environment (pending deployment)
- [ ] Verified referee contacts are created (pending deployment)

## Additional Context

### Why This Wasn't Caught Earlier

1. **Silent failure:** Authentication failed but didn't crash the service
2. **Calendar events still worked:** Used different code path with correct token
3. **Incomplete docker-compose setup:** Line 132 attempted to mount separate token but file was empty
4. **No integration tests:** People API authentication not tested in CI/CD

### Lessons Learned

1. ✅ Always use absolute paths for file references in containers
2. ✅ Use consistent environment variable names across services
3. ✅ Verify token scopes before assuming credentials are missing
4. ✅ Add integration tests for all API authentications

---

**Ready for review and merge!** 🚀

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author