### PR TITLE
fix: Update integration test to match Enhanced Schema v2.0 enriched callback format

### DIFF
--- a/tests/integration/test_redis_subscription.py
+++ b/tests/integration/test_redis_subscription.py
@@ -347,7 +347,24 @@ class TestEndToEndWorkflow(unittest.TestCase):
 
         # Check that calendar sync was called
         self.assertEqual(len(self.calendar_sync_calls), 1)
-        self.assertEqual(len(self.calendar_sync_calls[0]), 2)
+
+        # Verify enriched data format (Enhanced Schema v2.0)
+        enriched_data = self.calendar_sync_calls[0]
+        self.assertIsInstance(enriched_data, dict)
+        self.assertIn("matches", enriched_data)
+        self.assertIn("schema_version", enriched_data)
+        self.assertIn("detailed_changes", enriched_data)
+        self.assertIn("high_priority", enriched_data)
+
+        # Verify the matches content
+        self.assertEqual(len(enriched_data["matches"]), 2)
+        self.assertEqual(enriched_data["matches"][0]["matchid"], 123456)
+        self.assertEqual(enriched_data["matches"][1]["matchid"], 789012)
+
+        # Verify schema metadata
+        self.assertEqual(enriched_data["schema_version"], "1.0")
+        self.assertFalse(enriched_data["high_priority"])
+        self.assertEqual(enriched_data["detailed_changes"], [])
 
         # Check statistics
         stats = service.get_subscription_statistics()


### PR DESCRIPTION
## Problem

The nightly CI/CD workflow is failing during integration test execution. The specific test `TestEndToEndWorkflow.test_complete_message_flow` in `tests/integration/test_redis_subscription.py` fails with:

```
AssertionError: 4 != 2
```

At line 350:
```python
self.assertEqual(len(self.calendar_sync_calls[0]), 2)
```

**CI/CD Run:** https://github.com/PitchConnect/fogis-calendar-phonebook-sync/actions/runs/18300067696/job/52106010093

## Root Cause

This is a **breaking change** in the callback signature introduced in PR #124 (commit 0fa90c4) - "Enhanced Schema v2.0 Redis Subscription with Logo Service Integration".

**The Breaking Change:**
- **Before:** `calendar_sync_callback(matches)` - called with a list of match dictionaries
- **After:** `calendar_sync_callback(enriched_data)` - called with a dictionary containing 4 keys:
  - `matches`: List of match dictionaries
  - `schema_version`: String (e.g., "1.0", "2.0")
  - `detailed_changes`: List of change details
  - `high_priority`: Boolean flag

**Why the test fails:**
- The test expects `len(self.calendar_sync_calls[0])` to be 2 (number of matches)
- But `self.calendar_sync_calls[0]` is now a dictionary with 4 keys, so `len()` returns 4

## Solution

Updated the test assertions to properly validate the enriched data structure:

```python
# Verify enriched data format (Enhanced Schema v2.0)
enriched_data = self.calendar_sync_calls[0]
self.assertIsInstance(enriched_data, dict)
self.assertIn('matches', enriched_data)
self.assertIn('schema_version', enriched_data)
self.assertIn('detailed_changes', enriched_data)
self.assertIn('high_priority', enriched_data)

# Verify the matches content
self.assertEqual(len(enriched_data['matches']), 2)
self.assertEqual(enriched_data['matches'][0]['matchid'], 123456)
self.assertEqual(enriched_data['matches'][1]['matchid'], 789012)

# Verify schema metadata
self.assertEqual(enriched_data['schema_version'], '1.0')
self.assertFalse(enriched_data['high_priority'])
self.assertEqual(enriched_data['detailed_changes'], [])
```

## Testing

✅ All 14 integration tests pass:
```bash
pytest tests/integration/test_redis_subscription.py -v
```

✅ Specifically fixes: `TestEndToEndWorkflow::test_complete_message_flow`

✅ Pre-commit hooks pass (black, flake8, isort, pytest)

## Impact

- ✅ Fixes failing nightly CI/CD workflow
- ✅ Aligns test expectations with Enhanced Schema v2.0 implementation
- ✅ No changes to production code required
- ✅ No other tests affected (manual sync still uses simple list format)

## Related

- Fixes the CI/CD failure from the nightly workflow
- Related to PR #124 (Enhanced Schema v2.0 implementation)
- Should be merged to both `main` and `develop` branches

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author