### PR TITLE
Fix: docker-build.yml workflow syntax error (Issue #132)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,1 @@
+# Trigger Docker build

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -68,7 +68,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: .
-        push: ${{ github.event_name \!= 'pull_request' }}
+        push: ${{ github.event_name != 'pull_request' }}
         platforms: ${{ steps.platforms.outputs.platforms }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Problem

The `docker-build.yml` workflow has been failing immediately upon trigger with 0 jobs executed (runs #282, #283). This was blocking ARM64 Docker image builds.

## Root Cause

**Syntax error on line 71**: Invalid backslash escape character in GitHub Actions expression.

```yaml
# BEFORE (incorrect)
push: ${{ github.event_name \!= 'pull_request' }}

# AFTER (correct)
push: ${{ github.event_name != 'pull_request' }}
```

**Error Message**: `Unexpected symbol: '\'. Located at position 19 within expression: github.event_name \!= 'pull_request'`

## Solution

Removed the invalid backslash (`\`) before the `!=` operator. The `!=` operator in GitHub Actions expressions does not require escaping.

## Testing

- ✅ Pre-commit hooks passed (YAML validation)
- ✅ Syntax is now valid GitHub Actions expression format
- ✅ Will be tested by workflow run when PR is created

## Impact

Once merged, this will:
- ✅ Enable ARM64 Docker image builds for main branch pushes
- ✅ Enable ARM64 Docker image builds for tagged releases
- ✅ Complete the ARM64 deployment infrastructure (5/5 services with native ARM64)
- ✅ Eliminate the need for AMD64 emulation on fogis-calendar-phonebook-sync

## Related

- Fixes #132
- Related to PR #131 (which introduced this syntax error)
- Part of ARM64 deployment initiative

## Verification

After merge, verify by:
1. Checking that the workflow runs successfully
2. Confirming ARM64 image is built and pushed to GHCR
3. Updating docker-compose.yml to remove `platform: linux/amd64` override
4. Testing deployment with native ARM64 image

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author