### PR TITLE
Fix: Second docker-build.yml workflow syntax error on line 25

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,7 +22,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to GitHub Container Registry
-      if: github.event_name \!= 'pull_request'
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v3
       with:
         registry: ghcr.io


### PR DESCRIPTION
## Problem

The `docker-build.yml` workflow is **still failing** after PR #133 was merged. Run #285 failed with 0 jobs executed.

## Root Cause

**Second syntax error on line 25**: PR #133 fixed line 71, but **missed line 25** which has the same invalid backslash escape.

```yaml
# BEFORE (incorrect) - Line 25
if: github.event_name \!= 'pull_request'

# AFTER (correct)
if: github.event_name != 'pull_request'
```

**Error Message**: `Unexpected symbol: '\'. Located at position 19 within expression: github.event_name \!= 'pull_request'`

## Why PR #133 Didn't Fix This

PR #133 only fixed line 71 (the `push:` parameter in the build step). There was a **second occurrence** of the same syntax error on line 25 (the `if:` condition for the login step) that was not included in the fix.

## Solution

Removed the invalid backslash (`\`) before the `!=` operator on line 25.

## Testing

- ✅ Pre-commit hooks passed (YAML validation)
- ✅ Syntax is now valid GitHub Actions expression format
- ✅ Both occurrences of the syntax error are now fixed

## Impact

Once merged, this will:
- ✅ Enable the workflow to actually run (not fail immediately)
- ✅ Enable ARM64 Docker image builds for main branch pushes
- ✅ Enable ARM64 Docker image builds for tagged releases
- ✅ Complete the ARM64 deployment infrastructure (5/5 services with native ARM64)
- ✅ Eliminate the need for AMD64 emulation on fogis-calendar-phonebook-sync

## Related

- Fixes #132 (completely this time)
- Follow-up to PR #133 (which fixed line 71 but missed line 25)
- Part of ARM64 deployment initiative

## Verification

After merge, verify by:
1. Checking that the workflow runs successfully (jobs > 0)
2. Confirming ARM64 image is built and pushed to GHCR
3. Verifying `docker manifest inspect ghcr.io/pitchconnect/fogis-calendar-phonebook-sync:latest` shows both amd64 and arm64
4. Updating docker-compose.yml to remove `platform: linux/amd64` override
5. Testing deployment with native ARM64 image

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author