### PR TITLE
fix: Add environment variable override for USE_LOCAL_MATCH_DATA configuration

### DIFF
--- a/fogis_calendar_sync.py
+++ b/fogis_calendar_sync.py
@@ -61,6 +61,22 @@ try:
         config_dict = json.load(file)  # Load config data into a dictionary ONCE
 
     logger.info("Successfully loaded configuration from config.json.")
+
+    # Environment variable override for USE_LOCAL_MATCH_DATA
+    # This allows deployment configuration to override the config.json setting
+    # without modifying the container image
+    env_use_local = os.environ.get("USE_LOCAL_MATCH_DATA")
+    if env_use_local is not None:
+        # Convert string to boolean (handle "true"/"false" case-insensitively)
+        use_local_match_data = env_use_local.lower() in ("true", "1", "yes")
+        config_dict["USE_LOCAL_MATCH_DATA"] = use_local_match_data
+        logger.info(
+            f"USE_LOCAL_MATCH_DATA overridden by environment variable: {use_local_match_data}"
+        )
+    else:
+        logger.info(
+            f"USE_LOCAL_MATCH_DATA from config.json: {config_dict.get('USE_LOCAL_MATCH_DATA', False)}"
+        )
 except FileNotFoundError:
     logger.error("Configuration file not found: config.json. Exiting.")
     sys.exit(1)


### PR DESCRIPTION
## Problem

The calendar sync service has been experiencing recurring failures where it attempts to authenticate with FOGIS and fetch match data directly, instead of accepting pre-fetched match data from the `match-list-processor` service. This issue was documented in `CALENDAR_SYNC_ROOT_CAUSE_ANALYSIS.md` on October 5, 2025, but the fix was never implemented.

### Root Cause

The `config.json` file has `USE_LOCAL_MATCH_DATA: false` hardcoded, and there was no mechanism to override this setting via environment variables. This caused:

1. ❌ Service attempts to authenticate with FOGIS API
2. ❌ Service tries to fetch match data from FOGIS directly
3. ❌ Fails with "400 Bad Request" authentication error
4. ❌ Never processes the data sent by match-list-processor
5. ❌ Matches don't sync to Google Calendar

### Why This Keeps Recurring

Manual fixes inside the container are lost on every container recreation (updates, reboots), because:
- The Docker image contains the broken config.json
- No environment variable override existed
- Manual edits are not persisted

## Solution

This PR implements environment variable override support for `USE_LOCAL_MATCH_DATA`, allowing deployment configurations to override the config.json setting without modifying the container image.

### Changes Made

- ✅ Added `USE_LOCAL_MATCH_DATA` environment variable check after config.json load
- ✅ Supports boolean conversion from string values ("true"/"1"/"yes" case-insensitively)
- ✅ Maintains backward compatibility (config.json still works if env var not set)
- ✅ Added logging to indicate when environment variable override is active
- ✅ All pre-commit hooks pass (black, flake8, bandit, pytest)

### Code Changes

```python
# Environment variable override for USE_LOCAL_MATCH_DATA
# This allows deployment configuration to override the config.json setting
# without modifying the container image
env_use_local = os.environ.get("USE_LOCAL_MATCH_DATA")
if env_use_local is not None:
    # Convert string to boolean (handle "true"/"false" case-insensitively)
    use_local_match_data = env_use_local.lower() in ("true", "1", "yes")
    config_dict["USE_LOCAL_MATCH_DATA"] = use_local_match_data
    logger.info(
        f"USE_LOCAL_MATCH_DATA overridden by environment variable: {use_local_match_data}"
    )
else:
    logger.info(
        f"USE_LOCAL_MATCH_DATA from config.json: {config_dict.get('USE_LOCAL_MATCH_DATA', False)}"
    )
```

## Testing

- ✅ All pre-commit hooks pass
- ✅ Code formatting (black) passes
- ✅ Linting (flake8) passes
- ✅ Security checks (bandit) pass
- ✅ All tests (pytest) pass
- ✅ Backward compatibility maintained

## Deployment Instructions

After this PR is merged and a new Docker image is published:

1. Update `docker-compose.yml` in fogis-deployment repository:
   ```yaml
   fogis-calendar-phonebook-sync:
     environment:
       - USE_LOCAL_MATCH_DATA=true
   ```

2. Restart the service:
   ```bash
   docker-compose pull fogis-calendar-phonebook-sync
   docker-compose up -d fogis-calendar-phonebook-sync
   ```

## Expected Behavior After Fix

✅ Calendar sync will use data from match-list-processor
✅ No FOGIS authentication attempts from calendar sync service
✅ Matches will sync to Google Calendar successfully
✅ System will work as designed (separation of concerns)
✅ Fix persists across container recreations

## References

- Related documentation: `CALENDAR_SYNC_ROOT_CAUSE_ANALYSIS.md`
- Issue first documented: October 5, 2025
- Follows 12-factor app principles for configuration management

## Checklist

- [x] Code follows repository style guidelines
- [x] All pre-commit hooks pass
- [x] Backward compatibility maintained
- [x] Logging added for debugging
- [x] Documentation updated (commit message)
- [x] Ready for review

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author