### PR TITLE
Fix: Include referee data in calendar hash to detect referee changes

### DIFF
--- a/fogis_calendar_sync.py
+++ b/fogis_calendar_sync.py
@@ -203,7 +203,11 @@ def generate_match_hash(match):
 
 
 def generate_calendar_hash(match):
-    """Generates a hash for calendar-specific match data (excluding referee information)."""
+    """Generates a hash for calendar-specific match data (including referee information).
+
+    This hash is used to detect changes in match data that should trigger calendar updates.
+    Including referee data ensures that referee changes are properly detected and synced.
+    """
     data = {
         "lag1namn": match["lag1namn"],
         "lag2namn": match["lag2namn"],
@@ -211,6 +215,7 @@ def generate_calendar_hash(match):
         "tid": match["tid"],
         "tavlingnamn": match["tavlingnamn"],
         "kontaktpersoner": match.get("kontaktpersoner", []),  # Handle missing key
+        "domaruppdraglista": match.get("domaruppdraglista", []),  # Include referee data
     }
 
     data_string = json.dumps(data, sort_keys=True).encode("utf-8")

--- a/tests/test_fogis_calendar_sync.py
+++ b/tests/test_fogis_calendar_sync.py
@@ -150,10 +150,10 @@ def test_generate_calendar_hash():
     assert isinstance(calendar_hash1, str)
     assert len(calendar_hash1) == 64  # SHA-256 hash is 64 characters long
 
-    # Modify referee data - calendar hash should NOT change
+    # Modify referee data - calendar hash SHOULD change (referee data is now included)
     match["domaruppdraglista"][0]["personnamn"] = "Jane Doe"
     calendar_hash2 = fogis_calendar_sync.generate_calendar_hash(match)
-    assert calendar_hash1 == calendar_hash2  # Calendar hash unchanged
+    assert calendar_hash1 != calendar_hash2  # Calendar hash changed due to referee modification
 
     # Modify calendar data - calendar hash should change
     match["lag1namn"] = "New Home Team"


### PR DESCRIPTION
## Summary

Fixes #145 - Referee changes were not triggering calendar updates due to faulty hash implementation.

**This is a clean replacement for PR #148 which had merge conflicts and extra commits.**

## Problem

The `generate_calendar_hash()` function excluded `domaruppdraglista` (referee data) from the hash calculation. This caused referee changes to go undetected, preventing calendar updates from being triggered when referees were added, removed, or modified in FOGIS.

### Impact

- ❌ Referee changes were not synced to Google Calendar
- ❌ Calendar events showed outdated referee information
- ❌ Users had to manually check FOGIS for current referee assignments
- ❌ The hourly sync mechanism correctly published updates via Redis, but the calendar sync service ignored them

## Solution

Include `domaruppdraglista` in the calendar hash calculation. Now any change to referee assignments will be detected and trigger a calendar update.

### Changes Made

1. **Updated `generate_calendar_hash()` function:**
   - Added `"domaruppdraglista": match.get("domaruppdraglista", [])` to the hash data
   - Updated docstring to reflect that referee data is now included

2. **Updated test expectations:**
   - Modified `test_generate_calendar_hash()` to expect hash changes when referee data changes
   - This is the correct behavior - referee changes should trigger updates

### Code Changes

```python
# Before (BUGGY)
def generate_calendar_hash(match):
    """Generates a hash for calendar-specific match data (excluding referee information)."""
    data = {
        "lag1namn": match["lag1namn"],
        "lag2namn": match["lag2namn"],
        "anlaggningnamn": match["anlaggningnamn"],
        "tid": match["tid"],
        "tavlingnamn": match["tavlingnamn"],
        "kontaktpersoner": match.get("kontaktpersoner", []),
        # Missing: referee data!
    }
```

```python
# After (FIXED)
def generate_calendar_hash(match):
    """Generates a hash for calendar-specific match data (including referee information).
    
    This hash is used to detect changes in match data that should trigger calendar updates.
    Including referee data ensures that referee changes are properly detected and synced.
    """
    data = {
        "lag1namn": match["lag1namn"],
        "lag2namn": match["lag2namn"],
        "anlaggningnamn": match["anlaggningnamn"],
        "tid": match["tid"],
        "tavlingnamn": match["tavlingnamn"],
        "kontaktpersoner": match.get("kontaktpersoner", []),
        "domaruppdraglista": match.get("domaruppdraglista", []),  # ✅ Include referee data
    }
```

## Testing

✅ **All tests passing:** 510 passed, 80.10% coverage

### Real-World Verification

**Match:** IK Oddevold vs Helsingborgs IF (2025-11-08, Match ID: 6144752)

**Timeline:**
- 2025-11-06 06:27:44: Match processor caches 3 referees (no main referee yet)
- ~2025-11-06 17:50: Magnus Lindgren (#61646) added as main referee in FOGIS
- 2025-11-06 17:31-20:31: Hourly syncs run, show "No changes detected" ❌ (BUG!)
- 2025-11-06 20:42: Calendar hash fix deployed
- 2025-11-06 21:14:46: Cache cleared, all 4 referees detected
- 2025-11-06 21:15:07: Calendar updated successfully with all 4 referees ✅

**Before fix:** 3 referees cached, 4th referee (Magnus Lindgren) not synced  
**After fix:** All 4 referees detected and synced to calendar

## Related Investigation

See `SCHEDULING_INVESTIGATION_SUMMARY.md` in the `fogis-deployment` repository for complete analysis of the scheduling architecture and this bug.

## Checklist

- [x] Code changes implemented
- [x] Tests updated to reflect new behavior
- [x] All tests passing (510 passed, 80.10% coverage)
- [x] Real-world verification completed
- [x] Documentation updated (docstring)
- [x] Issue created and linked (#145)
- [x] Clean single commit (no merge conflicts)
- [x] Based on latest main branch

## Closes

#145

## Replaces

#148 (had merge conflicts and extra commits from develop branch)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author